### PR TITLE
[home] Implement Check In Survey screen and styling updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,8 +7,12 @@ import AppNavigator from './src/navigation/AppNavigator';
 import { AuthContextProvider } from './src/screens/auth/AuthContext';
 import { Amplify } from 'aws-amplify';
 import awsExports from './src/aws-exports';
+<<<<<<< HEAD
 import ProfileScreen from './src/screens/profile/ProfileScreen';
 import HomeScreen from './src/screens/home/HomeScreen';
+=======
+import CheckInSurveyScreen from './src/screens/home/CheckInSurvey';
+>>>>>>> c56da75 (Check In Survey WIP)
 Amplify.configure(awsExports);
 
 // Keep the splash screen visible while we fetch resources
@@ -62,7 +66,11 @@ export default function App() {
     <View style={styles.container} onLayout={onLayoutRootView}>
       <AuthContextProvider>
         {/* <AppNavigator /> */}
+<<<<<<< HEAD
         <HomeScreen />
+=======
+        <CheckInSurveyScreen />
+>>>>>>> c56da75 (Check In Survey WIP)
       </AuthContextProvider>
     </View>
   ) : null;

--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,9 @@ import AppNavigator from './src/navigation/AppNavigator';
 import { AuthContextProvider } from './src/screens/auth/AuthContext';
 import { Amplify } from 'aws-amplify';
 import awsExports from './src/aws-exports';
-import CheckInSurveyScreen from './src/screens/home/CheckInSurvey';
+import CheckInSurveyScreen from './src/screens/home/CheckInSurveyScreen';
+import CheckInSurveySubmittedScreen from './src/screens/home/CheckInSurveySubmittedScreen';
+import ReportSubmittedScreen from './src/screens/home/ReportSubmittedScreen';
 Amplify.configure(awsExports);
 
 // Keep the splash screen visible while we fetch resources
@@ -61,7 +63,8 @@ export default function App() {
     <View style={styles.container} onLayout={onLayoutRootView}>
       <AuthContextProvider>
         {/* <AppNavigator /> */}
-        <CheckInSurveyScreen />
+        <CheckInSurveySubmittedScreen />
+        {/* <ReportSubmittedScreen /> */}
       </AuthContextProvider>
     </View>
   ) : null;

--- a/App.tsx
+++ b/App.tsx
@@ -7,12 +7,7 @@ import AppNavigator from './src/navigation/AppNavigator';
 import { AuthContextProvider } from './src/screens/auth/AuthContext';
 import { Amplify } from 'aws-amplify';
 import awsExports from './src/aws-exports';
-<<<<<<< HEAD
-import ProfileScreen from './src/screens/profile/ProfileScreen';
-import HomeScreen from './src/screens/home/HomeScreen';
-=======
 import CheckInSurveyScreen from './src/screens/home/CheckInSurvey';
->>>>>>> c56da75 (Check In Survey WIP)
 Amplify.configure(awsExports);
 
 // Keep the splash screen visible while we fetch resources
@@ -66,11 +61,7 @@ export default function App() {
     <View style={styles.container} onLayout={onLayoutRootView}>
       <AuthContextProvider>
         {/* <AppNavigator /> */}
-<<<<<<< HEAD
-        <HomeScreen />
-=======
         <CheckInSurveyScreen />
->>>>>>> c56da75 (Check In Survey WIP)
       </AuthContextProvider>
     </View>
   ) : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/webpack-config": "^19.0.0",
         "@react-native-async-storage/async-storage": "1.18.2",
         "@react-native-community/netinfo": "9.3.10",
+        "@react-native-community/slider": "^4.4.4",
         "@react-navigation/native-stack": "^6.9.14",
         "@shopify/react-native-skia": "0.1.196",
         "@types/react-native": "~0.70.6",
@@ -9832,6 +9833,11 @@
       "peerDependencies": {
         "react-native": ">=0.59"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.4.4.tgz",
+      "integrity": "sha512-PEq9mTEVwOh+wuBvuuIslvC8gyGHfS2G01SJJWdbb4xz+u5559iuQXqDOUxQgFuN45dM0Ut1wMFDDdawN9RTEA=="
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.72.0",
@@ -28844,6 +28850,11 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-9.3.10.tgz",
       "integrity": "sha512-OwnqoJUp/4sa9e3ju+wQavAa8l0fiA3DheeLMKzKxtKeAe0CA7bNxWRM752JvRQ6A/igPnt1V0zSlu5owvQEuA==",
       "requires": {}
+    },
+    "@react-native-community/slider": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.4.4.tgz",
+      "integrity": "sha512-PEq9mTEVwOh+wuBvuuIslvC8gyGHfS2G01SJJWdbb4xz+u5559iuQXqDOUxQgFuN45dM0Ut1wMFDDdawN9RTEA=="
     },
     "@react-native/assets-registry": {
       "version": "0.72.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@expo/webpack-config": "^19.0.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/netinfo": "9.3.10",
+    "@react-native-community/slider": "^4.4.4",
     "@react-navigation/native-stack": "^6.9.14",
     "@shopify/react-native-skia": "0.1.196",
     "@types/react-native": "~0.70.6",

--- a/src/components/common/PopUpModal.tsx
+++ b/src/components/common/PopUpModal.tsx
@@ -69,27 +69,35 @@ export function PopUpModal({
           ) : null}
           <BodyText style={styles.bottomSpace} />
 
-          <CenteredRow>
-            <LeftAlignContainer style={{ marginLeft: 20 }}>
-              <TouchableOpacity onPress={onYes}>
-                <BodyText>
-                  <PurpleText>{yesOption}</PurpleText>
-                </BodyText>
-              </TouchableOpacity>
-            </LeftAlignContainer>
+          {noOption ? (
+            <CenteredRow>
+              <LeftAlignContainer style={{ marginLeft: 20 }}>
+                <TouchableOpacity onPress={onYes}>
+                  <BodyText>
+                    <PurpleText>{yesOption}</PurpleText>
+                  </BodyText>
+                </TouchableOpacity>
+              </LeftAlignContainer>
 
-            <BodyText selectable={false}>
-              <LightGrayText>|</LightGrayText>
-            </BodyText>
+              <BodyText selectable={false} style={{ width: 'auto' }}>
+                <LightGrayText>|</LightGrayText>
+              </BodyText>
 
-            <RightAlignContainer style={{ marginRight: 20 }}>
-              <TouchableOpacity onPress={onNo}>
-                <BodyText>
-                  <MidGrayText>{noOption}</MidGrayText>
-                </BodyText>
-              </TouchableOpacity>
-            </RightAlignContainer>
-          </CenteredRow>
+              <RightAlignContainer style={{ marginRight: 20 }}>
+                <TouchableOpacity onPress={onNo}>
+                  <BodyText>
+                    <MidGrayText>{noOption}</MidGrayText>
+                  </BodyText>
+                </TouchableOpacity>
+              </RightAlignContainer>
+            </CenteredRow>
+          ) : (
+            <TouchableOpacity onPress={onYes}>
+              <BodyText>
+                <PurpleText>{yesOption}</PurpleText>
+              </BodyText>
+            </TouchableOpacity>
+          )}
         </View>
       </Modal>
     </View>

--- a/src/navigation/stacks/TrainingStackNavigator.tsx
+++ b/src/navigation/stacks/TrainingStackNavigator.tsx
@@ -9,6 +9,7 @@ import ReportScreen from '../../screens/home/ReportScreen';
 import ReportSubmittedScreen from '../../screens/home/ReportSubmittedScreen';
 import EarTrainingScreen from '../../screens/exercise/EarTrainingScreen';
 import VoicePracticeScreen from '../../screens/exercise/VoicePracticeScreen';
+import CheckInSurveyScreen from '../../screens/home/CheckInSurvey';
 
 const TrainingStack = createNativeStackNavigator<TrainingStackParamList>();
 
@@ -39,6 +40,11 @@ export default function TrainingStackNavigator() {
         name="VoicePractice"
         component={VoicePracticeScreen}
       />
+      <TrainingStack.Screen
+        name="CheckInSurvey"
+        component={CheckInSurveyScreen}
+      />
+      {/* <TrainingStack.Screen name="CheckInSurveySubmitted" component={} /> */}
     </TrainingStack.Navigator>
   );
 }

--- a/src/navigation/stacks/TrainingStackNavigator.tsx
+++ b/src/navigation/stacks/TrainingStackNavigator.tsx
@@ -9,7 +9,8 @@ import ReportScreen from '../../screens/home/ReportScreen';
 import ReportSubmittedScreen from '../../screens/home/ReportSubmittedScreen';
 import EarTrainingScreen from '../../screens/exercise/EarTrainingScreen';
 import VoicePracticeScreen from '../../screens/exercise/VoicePracticeScreen';
-import CheckInSurveyScreen from '../../screens/home/CheckInSurvey';
+import CheckInSurveyScreen from '../../screens/home/CheckInSurveyScreen';
+import CheckInSurveySubmittedScreen from '../../screens/home/CheckInSurveySubmittedScreen';
 
 const TrainingStack = createNativeStackNavigator<TrainingStackParamList>();
 
@@ -44,7 +45,10 @@ export default function TrainingStackNavigator() {
         name="CheckInSurvey"
         component={CheckInSurveyScreen}
       />
-      {/* <TrainingStack.Screen name="CheckInSurveySubmitted" component={} /> */}
+      <TrainingStack.Screen
+        name="CheckInSurveySubmitted"
+        component={CheckInSurveySubmittedScreen}
+      />
     </TrainingStack.Navigator>
   );
 }

--- a/src/navigation/types.tsx
+++ b/src/navigation/types.tsx
@@ -22,6 +22,8 @@ export type TrainingStackParamList = {
   ReportSubmitted: undefined;
   EarTraining: undefined;
   VoicePractice: undefined;
+  CheckInSurvey: undefined;
+  CheckInSurveySubmitted: undefined;
 };
 
 export type TrainingStackScreenProps<T extends keyof TrainingStackParamList> =

--- a/src/screens/home/CheckInSurvey.tsx
+++ b/src/screens/home/CheckInSurvey.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import {
+  ScreenContainer,
+  HeadingContainer,
+  SafeArea,
+  ButtonContainer,
+} from '../../components/common/Containers';
+import { BodyText, H1Heading } from '../../../assets/Fonts';
+import {
+  BackButton,
+  GrayButton,
+  GreenButton,
+  PurpleButton,
+} from '../../components/common/Buttons';
+import InputField from '../../components/common/InputField';
+import { TrainingStackScreenProps } from '../../navigation/types';
+import { SelectField } from '../../components/profile/SelectField';
+import Colors from '../../../assets/Colors';
+import { PopUpModal } from '../../components/common/PopUpModal';
+
+export default function CheckInSurveyScreen({
+  navigation,
+}: TrainingStackScreenProps<'CheckInSurvey'>) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState('');
+  const [voiceGoals, setVoiceGoals] = useState('');
+  // TODO: fetch name & goals from database
+
+  const [unsavedChangesIsVisible, setUnsavedChangesIsVisible] = useState(false);
+  const [deleteAccountIsVisible, setDeleteAccountIsVisible] = useState(false);
+  const [deleteAccountInput, setDeleteAccountInput] = useState('');
+  const [deleteAccountError, setDeleteAccountError] = useState('');
+
+  const onChangeName = (value: string) => setName(value);
+  // TODO: change to dropdown
+  const onChangeVoiceGoals = (value: string) => setVoiceGoals(value);
+
+  const toggleEdit = () => {
+    setEditing(!editing);
+  };
+
+  const toggleUnsavedChanges = () => {
+    setUnsavedChangesIsVisible(!unsavedChangesIsVisible);
+  };
+  const discardChanges = () => {
+    navigation.goBack();
+    setUnsavedChangesIsVisible(false);
+  };
+
+  const onInputChange = (text: string) => {
+    setDeleteAccountInput(text);
+  };
+  const deleteAccount = () => {
+    if (name === deleteAccountInput) {
+      setDeleteAccountError('');
+      //TODO: delete account
+      setDeleteAccountIsVisible(false);
+      navigation.navigate('AccountDeleted');
+    } else {
+      setDeleteAccountError('The inputs do not match.');
+    }
+  };
+  const openDeleteAccountModal = () => {
+    setDeleteAccountIsVisible(true);
+  };
+  const closeDeleteAccountModal = () => {
+    setDeleteAccountInput('');
+    setDeleteAccountError('');
+    setDeleteAccountIsVisible(false);
+  };
+
+  return (
+    <SafeArea>
+      <BackButton navigation={navigation} onPress={toggleUnsavedChanges} />
+
+      <ScreenContainer>
+        <HeadingContainer>
+          <H1Heading>
+            {editing ? 'Your Profile' : 'Edit Your Profile'}
+          </H1Heading>
+        </HeadingContainer>
+
+        <BodyText>Preferred Name</BodyText>
+        <InputField value={name} onChange={onChangeName} editable={editing} />
+
+        <BodyText>Voice Goals</BodyText>
+        <InputField
+          value={voiceGoals}
+          onChange={onChangeVoiceGoals}
+          editable={editing}
+        />
+
+        <SelectField
+          text="Edit my voice goals"
+          color={Colors.lightPurple}
+          onPress={() => {
+            navigation.navigate('VoiceGoals');
+          }}
+          disabled={editing}
+        />
+
+        <SelectField
+          text="Delete my account"
+          color={Colors.cream}
+          onPress={openDeleteAccountModal}
+          disabled={editing}
+        />
+
+        <ButtonContainer>
+          <PurpleButton
+            onPress={toggleEdit}
+            text={editing ? 'Save' : 'Edit Profile'}
+          />
+          {editing ? (
+            <GrayButton onPress={toggleEdit} text="Discard Changes" />
+          ) : (
+            <GreenButton onPress={() => {}} text="Sign out" />
+          )}
+        </ButtonContainer>
+      </ScreenContainer>
+
+      <PopUpModal
+        isVisible={unsavedChangesIsVisible}
+        title="You have unsaved changes"
+        text="Are you sure you want to discard your changes?"
+        yesOption="Confirm"
+        noOption="Cancel"
+        onYes={discardChanges}
+        onNo={toggleUnsavedChanges}
+      />
+
+      <PopUpModal
+        isVisible={deleteAccountIsVisible}
+        title="Are you sure you want to delete your account?"
+        text={`This will delete all your history, personal information, and goals. This action is irreversible.\n
+        Type your name to confirm.`}
+        yesOption="Confirm"
+        noOption="Cancel"
+        onYes={deleteAccount}
+        onNo={closeDeleteAccountModal}
+        input={deleteAccountInput}
+        onInputChange={onInputChange}
+        errorText={deleteAccountError}
+      />
+    </SafeArea>
+  );
+}

--- a/src/screens/home/CheckInSurvey.tsx
+++ b/src/screens/home/CheckInSurvey.tsx
@@ -4,8 +4,9 @@ import {
   HeadingContainer,
   SafeArea,
   ButtonContainer,
+  Row,
 } from '../../components/common/Containers';
-import { BodyText, H1Heading } from '../../../assets/Fonts';
+import { BodyText, H1Heading, YellowText } from '../../../assets/Fonts';
 import {
   BackButton,
   GrayButton,
@@ -17,130 +18,74 @@ import { TrainingStackScreenProps } from '../../navigation/types';
 import { SelectField } from '../../components/profile/SelectField';
 import Colors from '../../../assets/Colors';
 import { PopUpModal } from '../../components/common/PopUpModal';
+import Slider from '@react-native-community/slider';
+import { MaterialIcons } from '@expo/vector-icons';
+import Icon from 'react-native-vector-icons/AntDesign';
 
 export default function CheckInSurveyScreen({
   navigation,
 }: TrainingStackScreenProps<'CheckInSurvey'>) {
-  const [editing, setEditing] = useState(false);
+  // TODO: fetch name from database
   const [name, setName] = useState('');
-  const [voiceGoals, setVoiceGoals] = useState('');
-  // TODO: fetch name & goals from database
+  const [trainingTime, setTrainingTime] = useState('');
+  const [dialogueIsVisible, setDialogueIsVisible] = useState(false);
 
-  const [unsavedChangesIsVisible, setUnsavedChangesIsVisible] = useState(false);
-  const [deleteAccountIsVisible, setDeleteAccountIsVisible] = useState(false);
-  const [deleteAccountInput, setDeleteAccountInput] = useState('');
-  const [deleteAccountError, setDeleteAccountError] = useState('');
+  const toHomeScreen = () => {
+    navigation.navigate('Home');
+  };
 
-  const onChangeName = (value: string) => setName(value);
   // TODO: change to dropdown
-  const onChangeVoiceGoals = (value: string) => setVoiceGoals(value);
+  const onChangeTrainingTime = (value: string) => setTrainingTime(value);
 
-  const toggleEdit = () => {
-    setEditing(!editing);
-  };
-
-  const toggleUnsavedChanges = () => {
-    setUnsavedChangesIsVisible(!unsavedChangesIsVisible);
-  };
-  const discardChanges = () => {
-    navigation.goBack();
-    setUnsavedChangesIsVisible(false);
-  };
-
-  const onInputChange = (text: string) => {
-    setDeleteAccountInput(text);
-  };
-  const deleteAccount = () => {
-    if (name === deleteAccountInput) {
-      setDeleteAccountError('');
-      //TODO: delete account
-      setDeleteAccountIsVisible(false);
-      navigation.navigate('AccountDeleted');
-    } else {
-      setDeleteAccountError('The inputs do not match.');
-    }
-  };
-  const openDeleteAccountModal = () => {
-    setDeleteAccountIsVisible(true);
-  };
-  const closeDeleteAccountModal = () => {
-    setDeleteAccountInput('');
-    setDeleteAccountError('');
-    setDeleteAccountIsVisible(false);
+  const toggleDialogue = () => {
+    setDialogueIsVisible(!dialogueIsVisible);
   };
 
   return (
     <SafeArea>
-      <BackButton navigation={navigation} onPress={toggleUnsavedChanges} />
-
       <ScreenContainer>
         <HeadingContainer>
-          <H1Heading>
-            {editing ? 'Your Profile' : 'Edit Your Profile'}
-          </H1Heading>
+          <H1Heading>Check-in Survey</H1Heading>
         </HeadingContainer>
 
-        <BodyText>Preferred Name</BodyText>
-        <InputField value={name} onChange={onChangeName} editable={editing} />
+        {/* TODO: replace with user's name*/}
+        <BodyText>
+          {`Hi, [name], it looks like you've been using our app for a while! Mind filling out a quick check-in survey?
+          \n1. On a scale from 1-10, how satisfied are you with your current voice?`}
+        </BodyText>
 
-        <BodyText>Voice Goals</BodyText>
-        <InputField
-          value={voiceGoals}
-          onChange={onChangeVoiceGoals}
-          editable={editing}
-        />
+        <Row style={{ marginTop: 20, marginBottom: 30 }}>
+          <Icon name="frowno" size={24} color={Colors.lightPurple} />
+          <Slider
+            style={{ width: 265, height: 40 }}
+            minimumValue={1}
+            maximumValue={10}
+            minimumTrackTintColor={Colors.yellow}
+            maximumTrackTintColor={Colors.yellow}
+            thumbTintColor={Colors.green}
+            step={1}
+          />
+          <Icon name="smileo" size={24} color={Colors.lightGreen} />
+        </Row>
 
-        <SelectField
-          text="Edit my voice goals"
-          color={Colors.lightPurple}
-          onPress={() => {
-            navigation.navigate('VoiceGoals');
-          }}
-          disabled={editing}
-        />
-
-        <SelectField
-          text="Delete my account"
-          color={Colors.cream}
-          onPress={openDeleteAccountModal}
-          disabled={editing}
-        />
+        <BodyText>2. How long have you been voice training?</BodyText>
+        {/* TODO: replace with dropdown */}
+        <InputField value={trainingTime} onChange={onChangeTrainingTime} />
 
         <ButtonContainer>
-          <PurpleButton
-            onPress={toggleEdit}
-            text={editing ? 'Save' : 'Edit Profile'}
-          />
-          {editing ? (
-            <GrayButton onPress={toggleEdit} text="Discard Changes" />
-          ) : (
-            <GreenButton onPress={() => {}} text="Sign out" />
-          )}
+          <PurpleButton onPress={toHomeScreen} text="Submit" />
+          <GrayButton onPress={toggleDialogue} text="Quit" />
         </ButtonContainer>
       </ScreenContainer>
 
       <PopUpModal
-        isVisible={unsavedChangesIsVisible}
-        title="You have unsaved changes"
-        text="Are you sure you want to discard your changes?"
+        isVisible={dialogueIsVisible}
+        title="Are you sure you want to discard this survey?"
+        text={`Your participation means a lot to us, and helps us collect data for research and improve the app.`}
         yesOption="Confirm"
         noOption="Cancel"
-        onYes={discardChanges}
-        onNo={toggleUnsavedChanges}
-      />
-
-      <PopUpModal
-        isVisible={deleteAccountIsVisible}
-        title="Are you sure you want to delete your account?"
-        text={`This will delete all your history, personal information, and goals. This action is irreversible.\n
-        Type your name to confirm.`}
-        yesOption="Confirm"
-        noOption="Cancel"
-        onYes={deleteAccount}
-        onNo={closeDeleteAccountModal}
-        input={deleteAccountInput}
-        onInputChange={onInputChange}
-        errorText={deleteAccountError}
+        onYes={toHomeScreen}
+        onNo={toggleDialogue}
       />
     </SafeArea>
   );

--- a/src/screens/home/CheckInSurveyScreen.tsx
+++ b/src/screens/home/CheckInSurveyScreen.tsx
@@ -6,20 +6,13 @@ import {
   ButtonContainer,
   Row,
 } from '../../components/common/Containers';
-import { BodyText, H1Heading, YellowText } from '../../../assets/Fonts';
-import {
-  BackButton,
-  GrayButton,
-  GreenButton,
-  PurpleButton,
-} from '../../components/common/Buttons';
+import { BodyText, H1Heading } from '../../../assets/Fonts';
+import { GrayButton, PurpleButton } from '../../components/common/Buttons';
 import InputField from '../../components/common/InputField';
 import { TrainingStackScreenProps } from '../../navigation/types';
-import { SelectField } from '../../components/profile/SelectField';
 import Colors from '../../../assets/Colors';
 import { PopUpModal } from '../../components/common/PopUpModal';
 import Slider from '@react-native-community/slider';
-import { MaterialIcons } from '@expo/vector-icons';
 import Icon from 'react-native-vector-icons/AntDesign';
 
 export default function CheckInSurveyScreen({
@@ -32,6 +25,10 @@ export default function CheckInSurveyScreen({
 
   const toHomeScreen = () => {
     navigation.navigate('Home');
+  };
+
+  const toSubmissionScreen = () => {
+    navigation.navigate('CheckInSurveySubmitted');
   };
 
   // TODO: change to dropdown
@@ -73,7 +70,7 @@ export default function CheckInSurveyScreen({
         <InputField value={trainingTime} onChange={onChangeTrainingTime} />
 
         <ButtonContainer>
-          <PurpleButton onPress={toHomeScreen} text="Submit" />
+          <PurpleButton onPress={toSubmissionScreen} text="Submit" />
           <GrayButton onPress={toggleDialogue} text="Quit" />
         </ButtonContainer>
       </ScreenContainer>

--- a/src/screens/home/CheckInSurveySubmittedScreen.tsx
+++ b/src/screens/home/CheckInSurveySubmittedScreen.tsx
@@ -3,14 +3,15 @@ import {
   SafeArea,
   StartContainer,
   ButtonContainer,
+  HeadingContainer,
 } from '../../components/common/Containers';
-import { H2Heading } from '../../../assets/Fonts';
+import { BodyText, H1Heading } from '../../../assets/Fonts';
 import { TrainingStackScreenProps } from '../../navigation/types';
 import { PurpleButton } from '../../components/common/Buttons';
 
-export default function ReportSubmittedScreen({
+export default function CheckInSurveySubmittedScreen({
   navigation,
-}: TrainingStackScreenProps<'ReportSubmitted'>) {
+}: TrainingStackScreenProps<'CheckInSurveySubmitted'>) {
   const toHome = () => {
     navigation.navigate('Home');
   };
@@ -18,10 +19,15 @@ export default function ReportSubmittedScreen({
   return (
     <SafeArea>
       <StartContainer>
-        <H2Heading>Your report has been submitted.</H2Heading>
+        <HeadingContainer>
+          <H1Heading>{'Survey\nsubmitted.'}</H1Heading>
+        </HeadingContainer>
+        <BodyText>
+          {'Thanks for taking the time to help\nfurther our research!'}
+        </BodyText>
 
         <ButtonContainer>
-          <PurpleButton text="Return to Home Screen" onPress={toHome} />
+          <PurpleButton text="Next" onPress={toHome} />
         </ButtonContainer>
       </StartContainer>
     </SafeArea>

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -76,7 +76,7 @@ export default function ProfileScreen({
       <ScreenContainer>
         <HeadingContainer>
           <H1Heading>
-            {editing ? 'Your Profile' : 'Edit Your Profile'}
+            {editing ? 'Edit Your Profile' : 'Your Profile'}
           </H1Heading>
         </HeadingContainer>
 


### PR DESCRIPTION
# ✨ New in this PR ✨
- Implemented Check In Survey and Check In Survey Submitted screens
- Updated styling for pop-up modal and Profile screen
- Cleaned up imports on Report Submitted screen
- Updated navigation components for Check In Survey and Check In Survey Submitted screens

## Next Steps
- There is no way for users to access the Check In Survey screen right now. It's unclear whether we should timegate the survey or send it to users after they've used the app a certain number of days; either way, the event trigger will probably require activity tracking that we don't currently have implemented, so it's probably okay to deprioritize this